### PR TITLE
Give lua access to console:log/info/warn/error/debug functions because why not!

### DIFF
--- a/ScriptingMod/ScriptEngines/LuaEngine.cs
+++ b/ScriptingMod/ScriptEngines/LuaEngine.cs
@@ -27,6 +27,7 @@ namespace ScriptingMod.ScriptEngines
             _lua = new Lua();
             _lua.LoadCLRPackage();
             _lua["print"] = new Action<object[]>(Print);
+            _lua["console"] = new JsConsole();
         }
 
         protected override void ExecuteFile(string filePath)

--- a/ScriptingMod/scripts/dj-test-lua.lua
+++ b/ScriptingMod/scripts/dj-test-lua.lua
@@ -27,6 +27,11 @@
 --   dump(variable[, maxDepth])        Dumps .Net objects in readable form into the log file.
 --                                     maxDepth = How deep the structure is traversed; default: 1
 --   print(text)                       Prints the text to console and log file
+--   console:log                       Same as print().
+--   console:info                      Same as print() but with INF marker.
+--   console:warn                      Same as print() but with WRN marker.
+--   console:error                     Same as print() but with ERR marker.
+--   console:debug                     Same as print() but with DBG marker.
 
 if params.Length == 2 then
     print("Hello " .. params[0] .. " " .. params[1] .. ", nice to meet you! I am a Lua script.")


### PR DESCRIPTION
Adds the "JsConsole" to Lua!
Call them like so:

    console:log("Lua console:log()");
    console:info("Lua console:info()");
    console:warn("Lua console:warn()");
    console:error("Lua console:error()");
    console:debug("Lua console:debug()");
